### PR TITLE
Fix crash #642

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -23,6 +23,10 @@ toc: false
 
 - Null Safety
 
+## 7.8.0
+
+- tau_core is now published on JitPack instead of Jfrog/Bintray
+
 ## 7.7.0
 
 - Flutter Sound on web : now we can record AAC-MP4 on webkit (iOS web browsers and Safari). [#559](https://github.com/Canardoux/tau/issues/559)

--- a/flutter_sound/ios/Classes/FlutterSoundPlayerManager.mm
+++ b/flutter_sound/ios/Classes/FlutterSoundPlayerManager.mm
@@ -44,7 +44,10 @@ FlutterSoundPlayerManager* flutterSoundPlayerManager = nil; // Singleton
         FlutterMethodChannel* aChannel = [FlutterMethodChannel methodChannelWithName:@"com.dooboolab.flutter_sound_player"
                                         binaryMessenger:[registrar messenger]];
         if (flutterSoundPlayerManager != nil)
+        {
                 NSLog(@"ERROR during registerWithRegistrar: flutterSoundPlayerManager != nil");
+                return;
+        }
         flutterSoundPlayerManager = [[FlutterSoundPlayerManager alloc] init];
         flutterSoundPlayerManager ->channel = aChannel;
         [registrar addMethodCallDelegate: flutterSoundPlayerManager channel: aChannel];


### PR DESCRIPTION
This is a workaround to fix crash #642.

I just added a return statement before we reach the code that crashes.

So far it seems that my app doesn't crash when I use it along just_audio.