### PR TITLE
Update dev docs to use URL instead of SSH for git clone command

### DIFF
--- a/doc/pages/the-tau-project/tau_dev.md
+++ b/doc/pages/the-tau-project/tau_dev.md
@@ -25,7 +25,7 @@ Pull Requests are welcome and will be considered very carefully.
 
 ```sh
 cd some_where
-git clone git@github.com:Canardoux/tau.git
+git clone https://github.com/Canardoux/tau.git
 ```
 
 ### setup a development environment


### PR DESCRIPTION
If someone doesn't have SSH keys configured with GitHub, the command would fail so prefer URL instead. Maybe the docs should include instructions to fork the project and clone that fork instead; open for discussion.