### PR TITLE
Basic fixes to widget UI

### DIFF
--- a/flutter_sound/lib/public/ui/recorder_playback_controller.dart
+++ b/flutter_sound/lib/public/ui/recorder_playback_controller.dart
@@ -96,6 +96,16 @@ class _RecordPlaybackControllerState {
     _recorderState?.stop();
   }
 
+  void _onPlayerPlay() {
+    /// Disables the recorder interface during playback.
+    _recorderState!.recordingEnabled(false);
+  }
+
+  void _onPlayerStop() {
+    /// Re-enables the recorder interface.
+    _recorderState!.recordingEnabled(true);
+  }
+
   void _onRecorderStopped(Duration duration) {
     _logger.d('_onRecorderStopped');
     if (_playerState != null) {
@@ -169,4 +179,14 @@ void onRecordingPaused(BuildContext context) {
 ///
 void onRecordingResume(BuildContext context) {
   RecorderPlaybackController.of(context)!._state._onRecorderResume();
+}
+
+///
+void onPlaybackStart(BuildContext context) {
+  RecorderPlaybackController.of(context)!._state._onPlayerPlay();
+}
+
+///
+void onPlaybackEnd(BuildContext context) {
+  RecorderPlaybackController.of(context)!._state._onPlayerStop();
 }

--- a/flutter_sound/lib/public/ui/recorder_playback_controller.dart
+++ b/flutter_sound/lib/public/ui/recorder_playback_controller.dart
@@ -134,6 +134,16 @@ class _RecordPlaybackControllerState {
     }
   }
 
+  void _onRecorderNew() {
+    /// For the specific case of there already being something recorded and
+    /// recording again, the play button needs to be removed.
+    if (_playerState != null) {
+      _playerState!.playbackEnabled(enabled: false);
+    }
+  }
+
+  //todo: on adding new recording.
+
   void registerRecorder(SoundRecorderUIState recorderState) {
     _recorderState = recorderState;
 
@@ -182,11 +192,16 @@ void onRecordingResume(BuildContext context) {
 }
 
 ///
+void onRecordingNew(BuildContext context) {
+  RecorderPlaybackController.of(context)!._state._onRecorderNew();
+}
+
+///
 void onPlaybackStart(BuildContext context) {
-  RecorderPlaybackController.of(context)!._state._onPlayerPlay();
+  RecorderPlaybackController.of(context)?._state._onPlayerPlay();
 }
 
 ///
 void onPlaybackEnd(BuildContext context) {
-  RecorderPlaybackController.of(context)!._state._onPlayerStop();
+  RecorderPlaybackController.of(context)?._state._onPlayerStop();
 }

--- a/flutter_sound/lib/public/ui/sound_player_ui.dart
+++ b/flutter_sound/lib/public/ui/sound_player_ui.dart
@@ -511,11 +511,11 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
   void _start() async {
     var trck = _track;
     if (trck != null) {
-      onPlaybackStart(context);
       await _player
           .startPlayerFromTrack(trck, whenFinished: _onStopped)
           .then((_) {
         _playState = _PlayState.playing;
+        onPlaybackStart(context);
       }).catchError((dynamic e) {
         _logger.w('Error calling play() ${e.toString()}');
         _playState = _PlayState.stopped;

--- a/flutter_sound/lib/public/ui/sound_player_ui.dart
+++ b/flutter_sound/lib/public/ui/sound_player_ui.dart
@@ -304,6 +304,7 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
   }
 
   void _onStopped() {
+    onPlaybackEnd(context);
     setState(() {
       /// we can get a race condition when we stop the playback
       /// We have disabled the button and called stop.
@@ -431,6 +432,7 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
   /// Call [resume] to resume playing the audio.
   void resume() {
     setState(() {
+      onPlaybackStart(context);
       _transitioning = true;
       _playState = _PlayState.playing;
     });
@@ -450,6 +452,7 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
   void pause() {
     // pause the player
     setState(() {
+      onPlaybackEnd(context);
       _transitioning = true;
       _playState = _PlayState.paused;
     });
@@ -508,6 +511,7 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
   void _start() async {
     var trck = _track;
     if (trck != null) {
+      onPlaybackStart(context);
       await _player
           .startPlayerFromTrack(trck, whenFinished: _onStopped)
           .then((_) {
@@ -515,7 +519,6 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
       }).catchError((dynamic e) {
         _logger.w('Error calling play() ${e.toString()}');
         _playState = _PlayState.stopped;
-
         return null;
       }).whenComplete(() {
         _loading = false;
@@ -536,6 +539,7 @@ class SoundPlayerUIState extends State<SoundPlayerUI> {
   ///
   Future<void> _stop({bool supressState = false}) async {
     if (_player.isPlaying || _player.isPaused) {
+      onPlaybackEnd(context);
       await _player.stopPlayer().then<void>((_) {
         if (_playerSubscription != null) {
           _playerSubscription!.cancel();

--- a/flutter_sound/lib/public/ui/sound_recorder_ui.dart
+++ b/flutter_sound/lib/public/ui/sound_recorder_ui.dart
@@ -448,6 +448,7 @@ class SoundRecorderUIState extends State<SoundRecorderUI> {
       if (widget.onStart != null) {
         widget.onStart!();
       }
+      onRecordingNew(context);
       //controller(context);
     });
   }

--- a/flutter_sound/lib/public/ui/sound_recorder_ui.dart
+++ b/flutter_sound/lib/public/ui/sound_recorder_ui.dart
@@ -60,6 +60,9 @@ enum _RecorderState {
 
   /// Is paused
   isPaused,
+
+  /// Is disabled during playback
+  isDisabled
 }
 
 /// [RecordedAudio] is used to track the audio media
@@ -260,6 +263,20 @@ class SoundRecorderUIState extends State<SoundRecorderUI> {
     super.dispose();
   }
 
+  /// Mirroring the code that controls the playback UI, this allows the recorder
+  /// to be disabled during playback
+  void recordingEnabled(bool enabled){
+    // take no action if recording is currently ongoing or paused.
+    assert (_recorder.isRecording != true && _recorder.isPaused != true);
+    setState(() {
+      if (enabled){
+        _state = _RecorderState.isStopped;
+      } else {
+        _state = _RecorderState.isDisabled;
+      }
+    });
+  }
+
   Widget _buildButtons() {
     return Container(
         //height: 70,
@@ -321,8 +338,8 @@ class SoundRecorderUIState extends State<SoundRecorderUI> {
                 ),
                 InkWell(
                   onTap: _onTapStartStop,
-                  child: Icon(_isStopped ? Icons.brightness_1 : Icons.stop,
-                      color: _isStopped ? Colors.red : Colors.black),
+                  child: Icon(_isRecording? Icons.stop : Icons.brightness_1,
+                      color: _isDisabled ? Colors.grey : _isStopped ? Colors.red : Colors.black),
                 ),
               ]);
             }));
@@ -337,7 +354,7 @@ class SoundRecorderUIState extends State<SoundRecorderUI> {
             child: Icon(
               !_isPaused ? Icons.pause : Icons.play_arrow,
               //size: 30,
-              color: !_isStopped ? Colors.black : Colors.grey,
+              color: _isDisabled? Colors.grey : !_isStopped ? Colors.black : Colors.grey,
             )));
   }
 
@@ -358,16 +375,19 @@ class SoundRecorderUIState extends State<SoundRecorderUI> {
   }
 
   void _onTapStartStop() {
-    if (_isRecording || _isPaused) {
-      _stop();
-    } else {
-      _onRecord();
+    if (!_isDisabled) {
+      if (_isRecording || _isPaused) {
+        _stop();
+      } else {
+        _onRecord();
+      }
     }
   }
 
   bool get _isRecording => _state == _RecorderState.isRecording;
   bool get _isPaused => _state == _RecorderState.isPaused;
   bool get _isStopped => _state == _RecorderState.isStopped;
+  bool get _isDisabled => _state == _RecorderState.isDisabled;
 
   /// The `stop` methods stops the recording and calls
   /// the `onStopped` callback.


### PR DESCRIPTION
Not a complete set of fixes, but corrects the most glaring issues with the widget UI. If you create a RecorderPlaybackController with both a recorder and a player, the recorder is now disabled when the player is playing, which heads off a bunch of potential error states. Similarly, when recording the player is disabled. 

The widget UI still has a number of incomplete features but the basic functions now work consistently. Still needs a proper maintainer but this should keep it functional for a bit.